### PR TITLE
Allow to set pip executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ User-configurable defaults:
 
 ```yaml
 uwsgi_version
+pip_executable
 ```
 
 For example:
@@ -90,6 +91,7 @@ More practical example:
 
   vars:
     uwsgi_version: 2.0.13.1
+    pip_executable: pip3
 
   tasks:
     - name: Copy project-specific config file(s) for uWSGI 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@
 #
 
 #uwsgi_version:
+pip_executable: pip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,9 +20,9 @@
 
 
 - name: install uWSGI via pip
-  pip: name=uwsgi version={{ uwsgi_version }}  state=present
+  pip: name=uwsgi version={{ uwsgi_version }} state=present executable={{ pip_executable }}
   when: uwsgi_version is defined
 
 - name: install uWSGI via pip
-  pip: name=uwsgi state=present
+  pip: name=uwsgi state=present executable={{ pip_executable }}
   when: uwsgi_version is not defined


### PR DESCRIPTION
Since Python3 is there, it becomes more common to use uWSGI with Python 3 applications. The problem is that when it installed for Python 2.x it can't serve application that uses Python 3-based virtualenv. 
Sometimes it is also possible that user may want to have uWSGI installed in his virtualenv(and it still will work propely). 

This PR is a simple solution for the problem described.